### PR TITLE
[FEAT] 마이페이지 서브메뉴 컴포넌트 개발(#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.28.0",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.13",
@@ -14184,6 +14185,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.13",

--- a/src/components/common/MypageSubMenu.jsx
+++ b/src/components/common/MypageSubMenu.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+import { HiClipboardDocumentList  } from "react-icons/hi2";
+import { PiIdentificationBadgeFill, PiPencilLineBold } from "react-icons/pi";
+import { TbMessageChatbotFilled } from "react-icons/tb";
+// import { BiSolidChat } from "react-icons/bi";
+import { RiSettings4Fill } from "react-icons/ri";
+import { SiHomeassistantcommunitystore } from "react-icons/si";
+import { BsBookmarkFill } from "react-icons/bs";
+
+const MypageSubMenu = ({ userType }) => {
+  const [ activeMenu, setActiveMenu ] = useState(null); // 클릭된 항목 관리
+
+  // 알바생과 사장님의 공통 메뉴 항목
+  const commonMenu = [
+    { name: '체결 현황', path: '/MyPage/ContractStatus', icon: <HiClipboardDocumentList /> },
+    { name: '리뷰 관리', path: '/MyPage/ReviewManagement', icon: <PiPencilLineBold /> },
+    { name: '채팅방', path: '/MyPage/Chat', icon: <TbMessageChatbotFilled /> },
+    { name: '설정', path: '/MyPage/Settings', icon: <RiSettings4Fill /> }
+  ];
+
+  // 알바생 메뉴 항목(사장님은 없는 메뉴)
+  const workerMenu = [
+    { name: '나의 이력서', path: '/MyPage/MyResume', icon: <PiIdentificationBadgeFill /> },
+    ...commonMenu
+  ];
+
+  const ownerMenu = [
+    { name: '관심 알바', path: '/MyPage/SavedWorkers', icon: <BsBookmarkFill /> },
+    { name: '나의 매장', path: '/MyPage/MyStore', icon: <SiHomeassistantcommunitystore /> },
+    ...commonMenu
+  ];
+
+  // 사용자 타입에 맞는 메뉴 선택
+  const menuItems = userType === 'worker' ? workerMenu : ownerMenu;
+
+  // 메뉴 항목 클릭 시 activeMenu 상태 업데이트
+  const handleMenuClick = (name) => {
+    setActiveMenu(name);
+  };
+
+  return (
+    <SubMenuContainer>
+      <MenuList>
+        {menuItems.map((item) => (
+          <MenuItem 
+            key={item.name}
+            onClick={() => handleMenuClick(item.name)} 
+          >
+            <StyledLink to={item.path} active={activeMenu === item.name}>
+              <Icon>{item.icon}</Icon>
+              {item.name}
+            </StyledLink>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </SubMenuContainer>
+  );
+
+};
+
+export default MypageSubMenu;
+
+
+const SubMenuContainer = styled.div`
+  width: 250px;
+  padding: 20px;
+  
+  margin-top: 20vh;
+`;
+
+const MenuList = styled.ul`
+  list-style: none;
+
+  padding: 0;
+  margin: 0;
+`;
+
+const MenuItem = styled.li`
+  width: auto;
+  height: 50px;
+
+  display: flex;
+  align-items: center;
+
+  cursor: pointer;
+`;
+
+const StyledLink = styled(Link)`
+  width: 100%;
+  height: 100%;
+  padding: 0 15px;
+  border-radius: 15px;
+
+  text-decoration: none;
+  font-size: 1rem;
+
+  display: flex;
+  align-items: center;
+
+  background-color: ${(props) => props.active ? "rgba(123, 75, 66, 0.2)" : "transparent"}; 
+  font-weight: ${(props) => (props.active ? "bold" : "500")};
+  color: ${(props) => (props.active ? "#000000" : "#767676")};
+
+  // 호버 기능은 없애도 될 듯
+  &:hover {
+    background-color: rgba(123, 75, 66, 0.1);
+  }
+`;
+
+const Icon = styled.span`
+  font-size: 1.2rem;
+
+  margin-top: 5px;
+  margin-right: 10px;
+`;


### PR DESCRIPTION
## 💥이슈 설명
- 마이페이지에서 사용하는 서브메뉴바 컴포넌트를 개발합니다.
- 해당 컴포넌트는 사장/알바생 상태에 따라 다른 항목을 표시해야 합니다.
- 각 항목을 클릭했을 때 해당 페이지로 이동할 수 있도록 라우팅 기능을 포함합니다.
- 항목 클릭 시, 해당 항목에 대한 스타일링을 추가합니다.

## 📚할 일 목록
- [x] 마크업 작성
- [x] 사장/알바생 상태 구분
- [x] 페이지 라우팅 설정

## 🔄관련 작업
- branch : 4-feat-마이페이지-서브메뉴-컴포넌트-개발

## 👀참고 사항
- 서버에서 받아오는 변수(사장님/알바생) 부분은 변동될 수 있을 것 같습니다.

- 로그인 사용자가 사장님일 때
![스크린샷 2024-11-20 142412](https://github.com/user-attachments/assets/2a27f8bb-c53a-4c96-8768-8d2cf343b472)

- 로그인 사용자가 알바생일 때
![스크린샷 2024-11-20 145511](https://github.com/user-attachments/assets/30b88b40-edf8-4ba8-b60c-16844863caca)

- 사용법
```
userType으로 구분합니다.

사장님일 경우 : <MypageSubMenu userType={owner} />
알바생일 경우 : <MypageSubMenu userType={worker} />
```

## ⌛기한
- 완료 기한 : 2024.11.20 (수)