### PR TITLE
[FEAT] 채팅방 페이지 마크업 (#6)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,7 @@
 
 /* 예시: 버튼 스타일링 */
 button {
-    background-color: var(--primary-color-dark);
+    background-color: var(--primary-color);
     color: white;
     padding: 5px 8px;
     border: none;
@@ -10,5 +10,5 @@ button {
   }
   
   button:hover {
-    background-color: var(--secondary-color);
+    background-color: var(--primary-color-dark);
   }

--- a/src/App.css
+++ b/src/App.css
@@ -4,16 +4,11 @@
 button {
     background-color: var(--primary-color-dark);
     color: white;
-    padding: 10px 20px;
+    padding: 5px 8px;
     border: none;
     cursor: pointer;
   }
   
   button:hover {
     background-color: var(--secondary-color);
-  }
-  
-  /* 버튼 포커스 스타일 */
-  button:focus {
-    outline: 2px solid var(--secondary-color);
   }

--- a/src/Router.js
+++ b/src/Router.js
@@ -5,6 +5,7 @@ import MyPage from "./pages/MyPage/MyPage";
 import Login from "./pages/LoginPage";
 import Signup from "./pages/SignupPage";
 import ResumePage from "./pages/ResumePage";
+import ChattingPage from "./pages/ChattingPage";
 
 const AppRouter = () => {
   return (
@@ -15,6 +16,7 @@ const AppRouter = () => {
       <Route path="/mypage" element={<MyPage />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Signup />} />
+      <Route path="/chat" element={<ChattingPage />} />
     </Routes>
   );
 };

--- a/src/assets/data/chatDummy.json
+++ b/src/assets/data/chatDummy.json
@@ -1,0 +1,31 @@
+{
+    "rooms": [
+      {
+        "id": 1,
+        "name": "오아영",
+        "chatHistory": [
+          { "id": 1, "sender": "오아영", "message": "안녕하세요! 오늘 날씨 좋네요.", "isSender": false },
+          { "id": 2, "sender": "Me", "message": "네, 정말 좋습니다!", "isSender": true },
+          { "id": 3, "sender": "오아영", "message": "주말 계획 있으세요?", "isSender": false }
+        ]
+      },
+      {
+        "id": 2,
+        "name": "김태영",
+        "chatHistory": [
+          { "id": 1, "sender": "김태영", "message": "안녕하세요, 오랜만이에요.", "isSender": false },
+          { "id": 2, "sender": "Me", "message": "네, 정말 오랜만이네요!", "isSender": true },
+          { "id": 3, "sender": "김태영", "message": "요즘 어떻게 지내세요?", "isSender": false }
+        ]
+      },
+      {
+        "id": 3,
+        "name": "김아영",
+        "chatHistory": [
+          { "id": 1, "sender": "김아영", "message": "안녕하세요! 시간 괜찮으세요?", "isSender": false },
+          { "id": 2, "sender": "Me", "message": "네, 괜찮습니다!", "isSender": true },
+          { "id": 3, "sender": "김아영", "message": "잠깐 이야기할 수 있을까요?", "isSender": false }
+        ]
+      }
+    ]
+  }

--- a/src/assets/data/chatDummy.json
+++ b/src/assets/data/chatDummy.json
@@ -1,31 +1,34 @@
 {
-    "rooms": [
-      {
-        "id": 1,
-        "name": "오아영",
-        "chatHistory": [
-          { "id": 1, "sender": "오아영", "message": "안녕하세요! 오늘 날씨 좋네요.", "isSender": false },
-          { "id": 2, "sender": "Me", "message": "네, 정말 좋습니다!", "isSender": true },
-          { "id": 3, "sender": "오아영", "message": "주말 계획 있으세요?", "isSender": false }
-        ]
-      },
-      {
-        "id": 2,
-        "name": "김태영",
-        "chatHistory": [
-          { "id": 1, "sender": "김태영", "message": "안녕하세요, 오랜만이에요.", "isSender": false },
-          { "id": 2, "sender": "Me", "message": "네, 정말 오랜만이네요!", "isSender": true },
-          { "id": 3, "sender": "김태영", "message": "요즘 어떻게 지내세요?", "isSender": false }
-        ]
-      },
-      {
-        "id": 3,
-        "name": "김아영",
-        "chatHistory": [
-          { "id": 1, "sender": "김아영", "message": "안녕하세요! 시간 괜찮으세요?", "isSender": false },
-          { "id": 2, "sender": "Me", "message": "네, 괜찮습니다!", "isSender": true },
-          { "id": 3, "sender": "김아영", "message": "잠깐 이야기할 수 있을까요?", "isSender": false }
-        ]
-      }
-    ]
-  }
+  "rooms": [
+    {
+      "id": 1,
+      "name": "오아영",
+      "isNew": false,
+      "chatHistory": [
+        { "id": 1, "sender": "오아영", "message": "안녕하세요! 오늘 날씨 좋네요.", "isSender": false },
+        { "id": 2, "sender": "Me", "message": "네, 정말 좋습니다!", "isSender": true },
+        { "id": 3, "sender": "오아영", "message": "주말 계획 있으세요?", "isSender": false }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "김태영",
+      "isNew": false,
+      "chatHistory": [
+        { "id": 1, "sender": "김태영", "message": "안녕하세요, 오랜만이에요.", "isSender": false },
+        { "id": 2, "sender": "Me", "message": "네, 정말 오랜만이네요!", "isSender": true },
+        { "id": 3, "sender": "김태영", "message": "요즘 어떻게 지내세요?", "isSender": false }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "김아영",
+      "isNew": true,
+      "chatHistory": [
+        { "id": 1, "sender": "김아영", "message": "안녕하세요! 시간 괜찮으세요?", "isSender": false },
+        { "id": 2, "sender": "Me", "message": "네, 괜찮습니다!", "isSender": true },
+        { "id": 3, "sender": "김아영", "message": "잠깐 이야기할 수 있을까요?", "isSender": false }
+      ]
+    }
+  ]
+}

--- a/src/assets/icons/keyboard_arrow_left.svg
+++ b/src/assets/icons/keyboard_arrow_left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.705 16.59L11.125 12L15.705 7.41L14.295 6L8.29504 12L14.295 18L15.705 16.59Z" fill="#0E0E0E"/>
+</svg>

--- a/src/assets/icons/new_badge.svg
+++ b/src/assets/icons/new_badge.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" rx="10" fill="#F46161"/>
+<path d="M12.7152 6.72727V14H11.3871L8.22301 9.42259H8.16974V14H6.6321V6.72727H7.98153L11.1207 11.3011H11.1847V6.72727H12.7152Z" fill="white"/>
+</svg>

--- a/src/components/chat/ChatBubble.jsx
+++ b/src/components/chat/ChatBubble.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import styled from "styled-components";
+
+
+
+const ChatBubble = ({ message, sender, isSender }) => {
+  return (
+    <BubbleContainer isSender={isSender}>
+      {!isSender && <SenderName>{sender}</SenderName>}
+      <Message>{message}</Message>
+    </BubbleContainer>
+  );
+};
+
+export default ChatBubble;
+
+
+const BubbleContainer = styled.div`
+  max-width: 60%;
+  margin: 10px;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  background-color: ${(props) =>
+    props.isSender ? "var(--gray_light)" : "#ffffff"};
+  align-self: ${(props) => (props.isSender ? "flex-end" : "flex-start")};
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+`;
+
+const SenderName = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  color: #555555;
+  margin-bottom: 5px;
+`;
+
+const Message = styled.div`
+  color: #333333;
+`;

--- a/src/components/chat/ChatBubble.jsx
+++ b/src/components/chat/ChatBubble.jsx
@@ -1,33 +1,25 @@
 import React from "react";
 import styled from "styled-components";
 
-
-
 const ChatBubble = ({ message, sender, isSender }) => {
   return (
     <BubbleContainer isSender={isSender}>
       {!isSender && <SenderName>{sender}</SenderName>}
-      <Message>{message}</Message>
+      <Message isSender={isSender}>{message}</Message>
     </BubbleContainer>
   );
 };
 
 export default ChatBubble;
 
-
 const BubbleContainer = styled.div`
   max-width: 60%;
-  margin: 10px;
-  padding: 10px;
-  border-radius: 10px;
+  margin: 2px;
   font-size: 14px;
   line-height: 1.5;
   display: flex;
   flex-direction: column;
-  background-color: ${(props) =>
-    props.isSender ? "var(--gray_light)" : "#ffffff"};
   align-self: ${(props) => (props.isSender ? "flex-end" : "flex-start")};
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 `;
 
 const SenderName = styled.div`
@@ -39,4 +31,11 @@ const SenderName = styled.div`
 
 const Message = styled.div`
   color: #333333;
+  background-color: ${(props) =>
+    props.isSender ? "var(--primary-color-dark)" : "var(--gray_light)"};
+  color: ${(props) =>
+    props.isSender ? "white" : "black"};
+  padding: 10px;
+  border-radius: 10px;
+  margin: 0 8px;
 `;

--- a/src/components/chat/RoomList.jsx
+++ b/src/components/chat/RoomList.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const RoomList = () => {
+  return (
+    <div>RoomList</div>
+  )
+}
+
+export default RoomList

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -13,6 +13,8 @@ const Layout = ({ children }) => {
 };
 
 const Main = styled.main`
-  margin-top: 75.5px; //헤더 높이
+  padding-top: 75.5px; //헤더 높이
+  background-color: var(--gray_bg);
+  height: 100vh;
 `
 export default Layout;

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import Header from './Header';
 import Footer from './Footer';
-
+import styled from 'styled-components';
 const Layout = ({ children }) => {
   return (
     <div>
       <Header />
-      <main>{children}</main>
+      <Main>{children}</Main>
       <Footer />
     </div>
   );
 };
 
+const Main = styled.main`
+  margin-top: 75.5px; //헤더 높이
+`
 export default Layout;

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ a {
 :root {
   --primary-color: #7B4B42; /* 기본(primary) 색상 */
   --secondary-color: #F7B32B; /* 보조(secondary) 색상 */
-
+  --primary-color-20: #7b4b4220;
   --primary-color-light: #9E6F60;
   --primary-color-dark: #5A3A2E;  
   --secondary-color-light: #F9C756;

--- a/src/index.css
+++ b/src/index.css
@@ -54,4 +54,5 @@ a {
   --black: #121212;
   --disabled-color: #B0B0B0; /* 비활성화된 버튼이나 텍스트 색상 */
   --gray_light: #c8c8c8;
+  --gray_bg: #f9f9f9;
 }

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import styled from "styled-components";
+import ChatBubble from "../components/chat/ChatBubble";
+const messages = [
+  { id: 1, sender: "Alice", message: "안녕하세요!", isSender: false },
+  { id: 2, sender: "Me", message: "안녕하세요, 반갑습니다!", isSender: true },
+  { id: 3, sender: "Alice", message: "리액트 좋죠?", isSender: false },
+];
+const rooms = [
+  { id: 1, name: "오아영" },
+  { id: 2, name: "김태영" },
+  { id: 3, name: "김아영" },
+];
+
+const ChattingPage = () => {
+  return (
+    <ChatLayout>
+      <RoomList>
+        <ui>
+          {rooms.map((room) => (
+            <RoomItem key={room.id}>{room.name}</RoomItem>
+          ))}
+        </ui>
+      </RoomList>
+      <ChatArea>
+        {messages.map((msg) => (
+          <ChatBubble
+            key={msg.id}
+            sender={msg.sender}
+            message={msg.message}
+            isSender={msg.isSender}
+          />
+        ))}
+        <InputContainer>
+          <Input />
+          <SubmitBtn>전송</SubmitBtn>
+        </InputContainer>
+      </ChatArea>
+    </ChatLayout>
+  );
+};
+
+const ChatLayout = styled.div`
+  display: flex;
+  width: 100vw;
+  background-color: #f9f9f9;
+`;
+
+const RoomList = styled.nav`
+  width: 30vw;
+`;
+
+const RoomItem = styled.li`
+  padding: 12px;
+  cursor: pointer;
+  border-bottom: 1px solid #f0f0f0;
+
+  &:hover {
+    background-color: #cacaca;
+  }
+`;
+
+const ChatArea = styled.div`
+  width: 100%;
+`;
+const InputContainer = styled.div`
+  display: flex;
+  padding: 10px;
+  gap: 10px;
+`;
+const Input = styled.input`
+  width: 100%;
+  height: 30px;
+  padding: 10px;
+`;
+const SubmitBtn = styled.button`
+width: 60px`;
+export default ChattingPage;

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -1,29 +1,58 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import ChatBubble from "../components/chat/ChatBubble";
-const messages = [
-  { id: 1, sender: "Alice", message: "안녕하세요!", isSender: false },
-  { id: 2, sender: "Me", message: "안녕하세요, 반갑습니다!", isSender: true },
-  { id: 3, sender: "Alice", message: "리액트 좋죠?", isSender: false },
-];
-const rooms = [
-  { id: 1, name: "오아영" },
-  { id: 2, name: "김태영" },
-  { id: 3, name: "김아영" },
-];
+import chatData from "../assets/data/chatDummy.json"; 
 
 const ChattingPage = () => {
+  const rooms = chatData.rooms;
+
+  // 초기 상태
+  const [selectedRoom, setSelectedRoom] = useState(rooms[0].id);
+  const [chatHistory, setChatHistory] = useState(rooms[0].chatHistory);
+  const [currentChat, setCurrentChat] = useState("");
+
+
+  const handleInputChange = (e) => {
+    setCurrentChat(e.target.value);
+  };
+
+  const handleSend = () => {
+    if (currentChat.trim() === "") return;
+
+    const newMessage = {
+      id: chatHistory.length + 1,
+      sender: "Me",
+      message: currentChat,
+      isSender: true,
+    };
+
+    setChatHistory([...chatHistory, newMessage]);
+    setCurrentChat("");
+  };
+
+  
+  const handleRoomClick = (roomId) => {
+    const selectedRoomData = rooms.find((room) => room.id === roomId);
+    setSelectedRoom(roomId);
+    setChatHistory(selectedRoomData.chatHistory);
+  };
+
   return (
     <ChatLayout>
       <RoomList>
-        <ui>
-          {rooms.map((room) => (
-            <RoomItem key={room.id}>{room.name}</RoomItem>
-          ))}
-        </ui>
+        {rooms.map((room) => (
+          <RoomItem
+            key={room.id}
+            onClick={() => handleRoomClick(room.id)}
+            isSelected={room.id === selectedRoom}
+          >
+            {room.name}
+          </RoomItem>
+        ))}
       </RoomList>
+
       <ChatArea>
-        {messages.map((msg) => (
+        {chatHistory.map((msg) => (
           <ChatBubble
             key={msg.id}
             sender={msg.sender}
@@ -32,14 +61,21 @@ const ChattingPage = () => {
           />
         ))}
         <InputContainer>
-          <Input />
-          <SubmitBtn>전송</SubmitBtn>
+          <input
+            type="text"
+            value={currentChat}
+            onChange={handleInputChange}
+            placeholder="메시지를 입력하세요"
+            style={{ flex: 1, padding: "5px" }}
+          />
+          <SubmitBtn onClick={handleSend}>전송</SubmitBtn>
         </InputContainer>
       </ChatArea>
     </ChatLayout>
   );
 };
 
+// 스타일 컴포넌트
 const ChatLayout = styled.div`
   display: flex;
   width: 100vw;
@@ -48,12 +84,14 @@ const ChatLayout = styled.div`
 
 const RoomList = styled.nav`
   width: 30vw;
+  border-right: 1px solid #ccc;
 `;
 
-const RoomItem = styled.li`
+const RoomItem = styled.div`
   padding: 12px;
   cursor: pointer;
   border-bottom: 1px solid #f0f0f0;
+  background-color: ${(props) => (props.isSelected ? "#ddd" : "transparent")};
 
   &:hover {
     background-color: #cacaca;
@@ -61,18 +99,25 @@ const RoomItem = styled.li`
 `;
 
 const ChatArea = styled.div`
-  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;
+
 const InputContainer = styled.div`
   display: flex;
   padding: 10px;
   gap: 10px;
+
+  input {
+    width: 100%;
+    height: 30px;
+    padding: 10px;
+  }
 `;
-const Input = styled.input`
-  width: 100%;
-  height: 30px;
-  padding: 10px;
-`;
+
 const SubmitBtn = styled.button`
-width: 60px`;
+  width: 60px
+`;
 export default ChattingPage;

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import ChatBubble from "../components/chat/ChatBubble";
-import chatData from "../assets/data/chatDummy.json"; 
+import chatData from "../assets/data/chatDummy.json";
 
 const ChattingPage = () => {
   const rooms = chatData.rooms;
@@ -10,7 +10,7 @@ const ChattingPage = () => {
   const [selectedRoom, setSelectedRoom] = useState(rooms[0].id);
   const [chatHistory, setChatHistory] = useState(rooms[0].chatHistory);
   const [currentChat, setCurrentChat] = useState("");
-
+  const [isRoomListOpen, setIsRoomListOpen] = useState(true);
 
   const handleInputChange = (e) => {
     setCurrentChat(e.target.value);
@@ -30,16 +30,19 @@ const ChattingPage = () => {
     setCurrentChat("");
   };
 
-  
   const handleRoomClick = (roomId) => {
     const selectedRoomData = rooms.find((room) => room.id === roomId);
     setSelectedRoom(roomId);
     setChatHistory(selectedRoomData.chatHistory);
   };
 
+  const toggleRoomList = () => {
+    setIsRoomListOpen((prev) => !prev);
+  };
+
   return (
     <ChatLayout>
-      <RoomList>
+      <RoomList isRoomListOpen={isRoomListOpen}>
         {rooms.map((room) => (
           <RoomItem
             key={room.id}
@@ -50,7 +53,9 @@ const ChattingPage = () => {
           </RoomItem>
         ))}
       </RoomList>
-
+      <button onClick={toggleRoomList}>
+        {isRoomListOpen ? "목록 닫기" : "목록 열기"}
+      </button>
       <ChatArea>
         {chatHistory.map((msg) => (
           <ChatBubble
@@ -83,7 +88,7 @@ const ChatLayout = styled.div`
 `;
 
 const RoomList = styled.nav`
-  width: 30vw;
+  width: ${({ isRoomListOpen }) => (isRoomListOpen ? "30vw" : "0")};
   border-right: 1px solid #ccc;
 `;
 
@@ -91,7 +96,7 @@ const RoomItem = styled.div`
   padding: 12px;
   cursor: pointer;
   border-bottom: 1px solid #f0f0f0;
-  background-color: ${(props) => (props.isSelected ? "#ddd" : "transparent")};
+  background-color: ${(isSelected) => (isSelected ? "#ddd" : "transparent")};
 
   &:hover {
     background-color: #cacaca;
@@ -118,6 +123,6 @@ const InputContainer = styled.div`
 `;
 
 const SubmitBtn = styled.button`
-  width: 60px
+  width: 60px;
 `;
 export default ChattingPage;

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import ChatBubble from "../components/chat/ChatBubble";
 import chatData from "../assets/data/chatDummy.json";
 import { FaChevronLeft } from "react-icons/fa";
+import { ReactComponent as NewBadge } from "../assets/icons/new_badge.svg";
 
 const ChattingPage = () => {
   const rooms = chatData.rooms;
@@ -17,7 +18,7 @@ const ChattingPage = () => {
   };
   const handleKeyUp = (e) => {
     if (e.key === "Enter") {
-      handleSend(); // 엔터 키를 누르면 메시지 전송
+      handleSend();
     }
   };
 
@@ -48,8 +49,8 @@ const ChattingPage = () => {
   return (
     <ChatLayout>
       <RoomList isRoomListOpen={isRoomListOpen}>
-        <div>
-          <p>채팅방 목록</p>
+        <RoomListContainer>
+          <h3>채팅방 목록</h3>
           {isRoomListOpen &&
             rooms.map((room) => (
               <RoomItem
@@ -57,10 +58,14 @@ const ChattingPage = () => {
                 onClick={() => handleRoomClick(room.id)}
                 isSelected={room.id === selectedRoom}
               >
-                {room.name}
+                <TitleWrapper>
+                  <p>{room.name}</p>
+                  {room.isNew && <NewBadge>New</NewBadge>}
+                </TitleWrapper>
+                <span>{"최근 채팅 내용을 표시합니다."}</span>
               </RoomItem>
             ))}
-        </div>
+        </RoomListContainer>
         <ArrowIcon onClick={toggleRoomList} isRoomListOpen={isRoomListOpen} />
       </RoomList>
       <ChatArea>
@@ -107,37 +112,60 @@ const RoomList = styled.div`
   border-radius: 0 20px 20px 0;
   padding: 20px 10px;
   background-color: white;
-
-  p {
-    //추후 h1로 변경 필요
-    color: #000;
-    font-size: 16px;
-    font-weight: 700;
-    white-space: nowrap;
-  }
-
-  div {
-    display: ${({ isRoomListOpen }) => (isRoomListOpen ? "block" : "none")};
-    width: 100%;
-  }
 `;
-
 const ArrowIcon = styled(FaChevronLeft)`
   transform: ${({ isRoomListOpen }) =>
     isRoomListOpen ? "rotate(0deg)" : "rotate(180deg)"};
   transition: transform 0.5s ease;
   cursor: pointer;
-  align-self: top;
+  align-self: flex-start;
   margin-left: 5px;
 `;
 
+const RoomListContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  h3{
+    color: #000;
+    font-size: 16px;
+    font-weight: 700;
+    white-space: nowrap;
+    margin-bottom: 14px;
+    padding-left: 12px;
+  }
+`;
+
 const RoomItem = styled.div`
+  align-items: center;
   padding: 12px;
-  cursor: pointer;
   border-bottom: 1px solid #f0f0f0;
+  background-color: ${({ isSelected }) =>
+    isSelected ? "var(--primary-color-20)" : "transparent"};
   &:hover {
     background-color: #f0f0f0;
-    transition: 0.3s ease;
+  }
+  span {
+    font-weight: 100;
+    color: var(--gray_dark);
+    font-size: 12px;
+    display: block;
+  }
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between; 
+  width: 100%;
+  p {
+    font-weight: 700;
+    font-size: 14px;
+    display: inline;
+    margin-bottom:4px;
+  }
+  svg {
+    size: 10px;
   }
 `;
 

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -2,11 +2,11 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import ChatBubble from "../components/chat/ChatBubble";
 import chatData from "../assets/data/chatDummy.json";
+import { FaChevronLeft } from "react-icons/fa";
 
 const ChattingPage = () => {
   const rooms = chatData.rooms;
 
-  // 초기 상태
   const [selectedRoom, setSelectedRoom] = useState(rooms[0].id);
   const [chatHistory, setChatHistory] = useState(rooms[0].chatHistory);
   const [currentChat, setCurrentChat] = useState("");
@@ -14,6 +14,11 @@ const ChattingPage = () => {
 
   const handleInputChange = (e) => {
     setCurrentChat(e.target.value);
+  };
+  const handleKeyUp = (e) => {
+    if (e.key === "Enter") {
+      handleSend(); // 엔터 키를 누르면 메시지 전송
+    }
   };
 
   const handleSend = () => {
@@ -43,35 +48,39 @@ const ChattingPage = () => {
   return (
     <ChatLayout>
       <RoomList isRoomListOpen={isRoomListOpen}>
-        {rooms.map((room) => (
-          <RoomItem
-            key={room.id}
-            onClick={() => handleRoomClick(room.id)}
-            isSelected={room.id === selectedRoom}
-          >
-            {room.name}
-          </RoomItem>
-        ))}
+        <div>
+          <p>채팅방 목록</p>
+          {isRoomListOpen &&
+            rooms.map((room) => (
+              <RoomItem
+                key={room.id}
+                onClick={() => handleRoomClick(room.id)}
+                isSelected={room.id === selectedRoom}
+              >
+                {room.name}
+              </RoomItem>
+            ))}
+        </div>
+        <ArrowIcon onClick={toggleRoomList} isRoomListOpen={isRoomListOpen} />
       </RoomList>
-      <button onClick={toggleRoomList}>
-        {isRoomListOpen ? "목록 닫기" : "목록 열기"}
-      </button>
       <ChatArea>
-        {chatHistory.map((msg) => (
-          <ChatBubble
-            key={msg.id}
-            sender={msg.sender}
-            message={msg.message}
-            isSender={msg.isSender}
-          />
-        ))}
+        <ChatContainer>
+          {chatHistory.map((msg) => (
+            <ChatBubble
+              key={msg.id}
+              sender={msg.sender}
+              message={msg.message}
+              isSender={msg.isSender}
+            />
+          ))}
+        </ChatContainer>
         <InputContainer>
           <input
             type="text"
             value={currentChat}
-            onChange={handleInputChange}
             placeholder="메시지를 입력하세요"
-            style={{ flex: 1, padding: "5px" }}
+            onChange={handleInputChange}
+            onKeyUp={handleKeyUp}
           />
           <SubmitBtn onClick={handleSend}>전송</SubmitBtn>
         </InputContainer>
@@ -83,23 +92,52 @@ const ChattingPage = () => {
 // 스타일 컴포넌트
 const ChatLayout = styled.div`
   display: flex;
-  width: 100vw;
   background-color: #f9f9f9;
+  gap: 20px;
+  padding: 20px 20px 20px 0px;
+  height: 100%;
 `;
 
-const RoomList = styled.nav`
-  width: ${({ isRoomListOpen }) => (isRoomListOpen ? "30vw" : "0")};
-  border-right: 1px solid #ccc;
+const RoomList = styled.div`
+  display: flex;
+  width: ${({ isRoomListOpen }) => (isRoomListOpen ? "25vw" : "40px")};
+  overflow: hidden;
+  transition: width 0.5s ease;
+  border: 1px solid #ccc;
+  border-radius: 0 20px 20px 0;
+  padding: 20px 10px;
+  background-color: white;
+
+  p {
+    //추후 h1로 변경 필요
+    color: #000;
+    font-size: 16px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  div {
+    display: ${({ isRoomListOpen }) => (isRoomListOpen ? "block" : "none")};
+    width: 100%;
+  }
+`;
+
+const ArrowIcon = styled(FaChevronLeft)`
+  transform: ${({ isRoomListOpen }) =>
+    isRoomListOpen ? "rotate(0deg)" : "rotate(180deg)"};
+  transition: transform 0.5s ease;
+  cursor: pointer;
+  align-self: top;
+  margin-left: 5px;
 `;
 
 const RoomItem = styled.div`
   padding: 12px;
   cursor: pointer;
   border-bottom: 1px solid #f0f0f0;
-  background-color: ${(isSelected) => (isSelected ? "#ddd" : "transparent")};
-
   &:hover {
-    background-color: #cacaca;
+    background-color: #f0f0f0;
+    transition: 0.3s ease;
   }
 `;
 
@@ -107,22 +145,35 @@ const ChatArea = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  background-color: white;
+  padding: 16px;
+`;
+
+const ChatContainer = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 const InputContainer = styled.div`
   display: flex;
   padding: 10px;
   gap: 10px;
-
+  margin-top: auto;
   input {
     width: 100%;
     height: 30px;
-    padding: 10px;
+    padding: 20px;
+    border-radius: 10px;
+    border: 1px solid #3a3a3a;
   }
 `;
 
 const SubmitBtn = styled.button`
-  width: 60px;
+  width: 70px;
+  padding: 7px 10px;
+  border-radius: 10px;
 `;
+
 export default ChattingPage;

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -49,7 +49,7 @@ const ChattingPage = () => {
   return (
     <ChatLayout>
       <RoomList isRoomListOpen={isRoomListOpen}>
-        <RoomListContainer>
+        <RoomListContainer isRoomListOpen={isRoomListOpen}>
           <h3>채팅방 목록</h3>
           {isRoomListOpen &&
             rooms.map((room) => (
@@ -124,10 +124,9 @@ const ArrowIcon = styled(FaChevronLeft)`
 
 const RoomListContainer = styled.div`
   width: 100%;
-  display: flex;
-  flex-direction: column;
-
-  h3{
+  display: ${({ isRoomListOpen }) => (isRoomListOpen ? "block" : "none")};
+  transition: 0.5s ease-out;
+  h3 {
     color: #000;
     font-size: 16px;
     font-weight: 700;
@@ -156,13 +155,13 @@ const RoomItem = styled.div`
 
 const TitleWrapper = styled.div`
   display: flex;
-  justify-content: space-between; 
+  justify-content: space-between;
   width: 100%;
   p {
     font-weight: 700;
     font-size: 14px;
     display: inline;
-    margin-bottom:4px;
+    margin-bottom: 4px;
   }
   svg {
     size: 10px;


### PR DESCRIPTION
<!--
풀 리퀘스트(PR) 제목은 다음 형식을 따르세요:
[FEAT] : 새로운 기능 추가
[FIX] : 버그 수정
[IMPR] : 코드 개선
[DOC] : 문서 업데이트
[STYLE] : 코드 스타일 수정
[REFAC] : 리팩토링
-->

## ✨ PR 세부 내용
- 더미 데이터를 활용한 채팅방 목록 및 채팅 내역 표시
    - 채팅방 리스트 펼치기/닫기 기능 추가
    - 최근 메시지 미리보기, 새 메시지 알림 뱃지 추가
    - chatDummy.json는 gpt를 활용해서 만들었으며, api 연동 이후 삭제 예정입니다.
- 채팅 입력 후 Enter 키 또는 전송 버튼 클릭 시 메시지를 전송 (api 없이 useState 활용하여 임시 구현)

## 📝 관련 이슈
- #6 

## ⚠️주의 사항
- index.css에 추가된 색상 있는데, merge 시 충돌/삭제되지 않도록 주의해주세요

## 💬 리뷰 요청 사항
- 모든 페이지 background color를 `--gray_bg: #f9f9f9`로 설정햇는데 css에 문제잇는 분 말씀해주세요 😀

## ⏳ 기한
- 무관/연관된 기능 없음